### PR TITLE
Replace throw with reject

### DIFF
--- a/techs/enb-postcss.js
+++ b/techs/enb-postcss.js
@@ -41,7 +41,7 @@ module.exports = buildFlow.create()
                 if (error.name === 'CssSyntaxError') {
                     process.stderr.write(error.message + error.showSourceCode());
                 } else {
-                    throw error;
+                    def.reject(error);
                 }
             })
             .then(function (result) {


### PR DESCRIPTION
When non-syntax error occurs, enb (I’ve tested 1.2.0) doesn’t show error. 
