### PR TITLE
Add oneOfSourceSuffixes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ nodeConfig.addTech(
     [require('enb-postcss/techs/enb-postcss'), {
         comments : true,
         sourcemap : true,
-        plugins : [require('cssnext')()]
+        plugins : [require('cssnext')()],
+        oneOfSourceSuffixes : [['post.css', 'css'], ['ie.post.css', 'ie.css']] // keep just one of found tech. Default is undefined
     } ],
 );
 ```


### PR DESCRIPTION
Closes #34 

Possible values of `oneOfSourceSuffixes` option:
```js
null or any other falsy value // as if there was no oneOfSourceSuffixes option
'css' // keep just files with `css` tech
['post.css', 'css'] // keep just one of these techs, order is significant
[['post.css', 'css'], 'ie.css', 'styl'] // keep (post.css || css) + ie.css + styl
[['post.css', 'css'], ['ie.post.css', 'ie.css']] // (post.css || css) + ('ie.post.css' || 'ie.css')
[['post.css', 'css'], 'blah', ['ie.post.css', 'ie.css']] // (post.css || css) + blah + ('ie.post.css' || 'ie.css')
```